### PR TITLE
bmfont conversion

### DIFF
--- a/bmfont.lisp
+++ b/bmfont.lisp
@@ -1,0 +1,66 @@
+(defpackage #:sdf-bmfont
+  (:use :cl)
+  (:export #:to-bmfont
+           #:save-bmfont
+           #:create-bmfont))
+(in-package #:sdf-bmfont)
+
+(defun to-bmfont (atlas)
+  (let ((metrics (sdf:atlas-metrics atlas))
+        (chars (make-hash-table :test 'eql))
+        (dims (array-dimensions (sdf:atlas-image atlas))))
+    (destructuring-bind (height width channels) dims
+      (loop for glyph in (sdf:font-glyphs metrics)
+            for char = (sdf:glyph-character glyph)
+            for (x y w h) = (sdf:glyph-bounding-box glyph)
+            for (xo yo) = (sdf:glyph-origin glyph)
+            for i from 0
+            do (setf (gethash char chars)
+                     (list :id (char-code char)
+                           :index i
+                           :char (string char)
+                           :x x
+                           :y y
+                           :width w
+                           :height h
+                           :xoffset xo
+                           :yoffset yo
+                           :xadvance (sdf:glyph-advance-width glyph)
+                           :chnl (ecase channels (1 4) (2 6) (3 7) (4 15))
+                           :page 0)))
+      (make-instance '3b-bmfont-common:bmfont
+                     :face NIL
+                     :size (sdf:font-size metrics)
+                     :padding '(0 0 0 0)
+                     :spacing '(0 0)
+                     :base (sdf:font-ascender metrics)
+                     :line-height (+ (sdf:font-ascender metrics) (sdf:font-descender metrics) (sdf:font-line-gap metrics))
+                     :stretch-h 100
+                     :scale-w width
+                     :scale-h height
+                     :red-chnl (if (= 1 channels) :glyph :zero)
+                     :green-chnl (if (= 2 channels) :glyph :zero)
+                     :blue-chnl (if (= 3 channels) :glyph :zero)
+                     :alpha-chnl (if (= 4 channels) :glyph :zero)
+                     :chars chars
+                     :pages (make-array 1 :initial-element (list :id 0 :file NIL))
+                     :kernings (sdf:font-kerning-table metrics)
+                     :distance-field (list :field-type (sdf:atlas-field-type atlas)
+                                           :distance-range (sdf:atlas-distance-range atlas))))))
+
+(defun save-bmfont (atlas atlas-file bmfont-file &key type)
+  (let ((bmfont (to-bmfont atlas))
+        (relpath (namestring (pathname-utils:relative-pathname bmfont-file atlas-file))))
+    (setf (3b-bmfont-common:face bmfont) relpath)
+    (setf (getf (aref (3b-bmfont-common:pages bmfont) 0) :file) relpath)
+    (sdf:save-atlas atlas atlas-file)
+    (3b-bmfont:write-bmfont bmfont bmfont-file :type type)))
+
+(defun create-bmfont (font-file bmfont-file &rest args &key (size 24) type &allow-other-keys)
+  (let ((atlas-args (copy-list args)))
+    (remf atlas-args :size)
+    (remf atlas-args :type)
+    (save-bmfont (apply #'sdf:make-atlas font-file size atlas-args)
+                 (make-pathname :type "png" :defaults bmfont-file)
+                 bmfont-file
+                 :type type)))

--- a/metrics.lisp
+++ b/metrics.lisp
@@ -2,7 +2,8 @@
 
 
 (defstruct (font-metrics
-             (:conc-name font-))
+            (:conc-name font-))
+  (size nil :read-only t)
   (glyphs nil :read-only t)
   (ascender nil :read-only t)
   (descender nil :read-only t)
@@ -21,6 +22,8 @@
 
 
 (defstruct (atlas
-             (:constructor %make-atlas (image metrics)))
+            (:constructor %make-atlas (field-type distance-range image metrics)))
+  (field-type nil :read-only t)
+  (distance-range nil :read-only t)
   (image nil :read-only t)
   (metrics nil :read-only t))

--- a/packages.lisp
+++ b/packages.lisp
@@ -3,9 +3,12 @@
   (:export #:make-atlas
            #:save-atlas
 
+           #:atlas-field-type
+           #:atlas-distance-range
            #:atlas-image
            #:atlas-metrics
 
+           #:font-size
            #:font-glyphs
            #:font-ascender
            #:font-descender

--- a/sdf.asd
+++ b/sdf.asd
@@ -14,3 +14,11 @@
                (:file "msdf")
                (:file "sdf")))
 
+(asdf:defsystem :sdf/bmfont
+  :description "Convert an SDF atlas to a bmfont structure"
+  :version "0.0.1"
+  :author "Nicolas Hafner <shinmera@tymoon.eu>"
+  :license "MIT"
+  :depends-on (3b-bmfont sdf pathname-utils)
+  :serial t
+  :components ((:file "bmfont")))

--- a/sdf.lisp
+++ b/sdf.lisp
@@ -22,12 +22,14 @@
                             (* offset scale)))))))
      finally (return table)))
 
-(defun make-metrics (glyph-data scale ttf)
-  (make-font-metrics :glyphs (mapcar (lambda (g) (getf g :metrics)) glyph-data)
-                     :ascender (* scale (zpb-ttf:ascender ttf))
-                     :descender (* scale (zpb-ttf:descender ttf))
-                     :line-gap (* scale (zpb-ttf:line-gap ttf))
-                     :kerning-table (make-kerning-table glyph-data scale ttf)))
+(defun make-metrics (size glyph-data scale ttf)
+  (make-font-metrics
+   :size size
+   :glyphs (mapcar (lambda (g) (getf g :metrics)) glyph-data)
+   :ascender (* scale (zpb-ttf:ascender ttf))
+   :descender (* scale (zpb-ttf:descender ttf))
+   :line-gap (* scale (zpb-ttf:line-gap ttf))
+   :kerning-table (make-kerning-table glyph-data scale ttf)))
 
 (defun obtain-glyph-data (string font-scale scale spread ttf)
   (flet ((fscale (v)
@@ -126,7 +128,8 @@
                                      do (loop for i below 3
                                               do (setf (aref out oy ox i)
                                                        (aref sdf iy ix i))))))))
-         (%make-atlas out (make-metrics glyph-data font-scale ttf)))))))
+         ;; FIXME: I don't know if the 3 for the distance range is correct here.
+         (%make-atlas *backend* 3 out (make-metrics pixel-size glyph-data font-scale ttf)))))))
 
 (defun save-atlas (atlas png-filename)
   (opticl:write-image-file png-filename (atlas-image atlas)))

--- a/sdf.lisp
+++ b/sdf.lisp
@@ -128,6 +128,5 @@
                                                        (aref sdf iy ix i))))))))
          (%make-atlas out (make-metrics glyph-data font-scale ttf)))))))
 
-(defun save-atlas (atlas png-filename metrics-filename)
-  (declare (ignore metrics-filename))
+(defun save-atlas (atlas png-filename)
   (opticl:write-image-file png-filename (atlas-image atlas)))


### PR DESCRIPTION
Conversion is in a separate system, sdf/bmfont and thus incurs no additional dependency unless requested. Conversion is pretty primitive right now and I'm not sure it's entirely correct. A thorough review would be appreciated.

I'm especially unsure about the correct use of the x/yoffset and the padding/spacing parameters in bmfont.

I at least tested simple saving of a primitive atlas with text and json saving, which worked fine (after applying 3b/3b-bmfont#13). xml saving fails trying to "unparse-attribute" the line height, and I'm not sure that's a problem with this patch.